### PR TITLE
fix: removed object causing invalid react child rendering error when clicking on onboarding module 1

### DIFF
--- a/src/Components/Onboarding/ModuleContent.jsx
+++ b/src/Components/Onboarding/ModuleContent.jsx
@@ -109,7 +109,7 @@ const ModuleContent = ({ content }) => {
                     ) : (
                         ""
                     )}
-                    {paragraph1B ? { paragraph1B } : ""}
+                    {paragraph1B || ""}
                 </Typography>
             ) : null}
 


### PR DESCRIPTION
### Ticket(s)

[airtable ticket](https://airtable.com/appfJZShN8K4tcWHU/tblXQZfKPAJIjV4cL/viwD7biTj0KTIonPF/recFhcprlDOExCVpQ?blocks=hide)

### Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

### Description

I encountered this issue while going through the onboarding portion of the site. Modules 2, 3, and 4 work as expected. Module 1 caused the page to crash, full white screen. I inspected and found that the error was being caused by invalid rendering of an object as a child. I was able to resolve the issue by using the OR operator instead of using a ternary statement.

Fixes bug 242.

### Checklist:

-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation (if applicable)
-   [x] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
-   [ ] New and existing unit tests pass locally with my changes
